### PR TITLE
Update dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 // GCSAdapter
 // Store Parse Files in Google Cloud Storage: https://cloud.google.com/storage
-const storage = require('gcloud').storage;
+const storage = require('google-cloud').storage;
 
 function requiredOrFromEnvironment(options, key, env) {
   options[key] = options[key] || process.env[env];

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "gcloud": "^0.29.0"
+    "google-cloud": "^0.39.0"
   },
   "devDependencies": {
     "codecov": "^1.0.1",


### PR DESCRIPTION
gcloud has been deprecated in favor of google-cloud, see the installation warning:

```
npm WARN deprecated gcloud@0.29.0: gcloud has been renamed to google-cloud. 
To get new features and bug fixes, you must use the new package.
```
