### PR TITLE
Remove projectId & keyFilename requirements

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function optionsFromArguments(args) {
       options.directAccess = otherOptions.directAccess;
     }
   } else {
-    options = projectIdOrOptions || {};
+    options = Object.assign( {}, projectIdOrOptions);
   }
   options = fromEnvironmentOrDefault(options, 'projectId', 'GCP_PROJECT_ID', undefined);
   options = fromEnvironmentOrDefault(options, 'keyFilename', 'GCP_KEYFILE_PATH', undefined);

--- a/index.js
+++ b/index.js
@@ -31,8 +31,8 @@ function optionsFromArguments(args) {
   } else {
     options = projectIdOrOptions || {};
   }
-  options = requiredOrFromEnvironment(options, 'projectId', 'GCP_PROJECT_ID');
-  options = requiredOrFromEnvironment(options, 'keyFilename', 'GCP_KEYFILE_PATH');
+  options = fromEnvironmentOrDefault(options, 'projectId', 'GCP_PROJECT_ID', undefined);
+  options = fromEnvironmentOrDefault(options, 'keyFilename', 'GCP_KEYFILE_PATH', undefined);
   options = requiredOrFromEnvironment(options, 'bucket', 'GCS_BUCKET');
   options = fromEnvironmentOrDefault(options, 'bucketPrefix', 'GCS_BUCKET_PREFIX', '');
   options = fromEnvironmentOrDefault(options, 'directAccess', 'GCS_DIRECT_ACCESS', false);
@@ -55,12 +55,7 @@ function GCSAdapter() {
   this._bucketPrefix = options.bucketPrefix;
   this._directAccess = options.directAccess;
 
-  let storageOptions = {
-    projectId: options.projectId,
-    keyFilename: options.keyFilename
-  };
-
-  this._gcsClient = new storage(storageOptions);
+  this._gcsClient = new storage(options);
 }
 
 GCSAdapter.prototype.createFile = function(filename, data, contentType) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "devDependencies": {
     "codecov": "^1.0.1",
-    "expect": "^1.20.2",
     "istanbul": "^0.4.2",
     "jasmine": "^2.4.1",
     "parse-server-conformance-tests": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "codecov": "^1.0.1",
+    "expect": "^1.20.2",
     "istanbul": "^0.4.2",
     "jasmine": "^2.4.1",
     "parse-server-conformance-tests": "^1.0.0"

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -1,5 +1,6 @@
 'use strict';
-let filesAdapterTests = require('parse-server-conformance-tests').files;
+let filesAdapterTests = require('parse-server-conformance-tests').files,
+  expect = require('expect');
 
 let GCSAdapter = require('../index.js');
 
@@ -7,38 +8,40 @@ describe('GCSAdapter tests', () => {
 
   it('should throw when not initialized properly', () => {
     expect(() => {
-      var gcsAdapter = new GCSAdapter();
-    }).toThrow('GCSAdapter requires an projectId')
+      return new GCSAdapter();
+    }).toThrow('GCSAdapter requires an bucket');
 
     expect(() => {
-      var gcsAdapter = new GCSAdapter('projectId');
-    }).toThrow('GCSAdapter requires an keyFilename')
+      return new GCSAdapter('projectId');
+    }).toThrow('GCSAdapter requires an bucket');
 
     expect(() => {
-      var gcsAdapter = new GCSAdapter('projectId', 'keyFilename');
-    }).toThrow('GCSAdapter requires an bucket')
+      return new GCSAdapter('projectId', 'keyFilename');
+    }).toThrow('GCSAdapter requires an bucket');
 
     expect(() => {
-      var gcsAdapter = new GCSAdapter({ projectId: 'projectId'});
-    }).toThrow('GCSAdapter requires an keyFilename')
+      return new GCSAdapter({ projectId: 'projectId'});
+    }).toThrow('GCSAdapter requires an bucket');
+
     expect(() => {
-      var gcsAdapter = new GCSAdapter({ projectId: 'projectId' , keyFilename: 'keyFilename'});
-    }).toThrow('GCSAdapter requires an bucket')
-  })
+      return new GCSAdapter({ projectId: 'projectId' , keyFilename: 'keyFilename'});
+    }).toThrow('GCSAdapter requires an bucket');
+  });
 
   it('should not throw when initialized properly', () => {
     expect(() => {
-      var gcsAdapter = new GCSAdapter('projectId', 'keyFilename', 'bucket');
-    }).not.toThrow()
+      return new GCSAdapter('projectId', 'keyFilename', 'bucket');
+    }).toNotThrow();
 
     expect(() => {
-      var gcsAdapter = new GCSAdapter({ projectId: 'projectId' , keyFilename: 'keyFilename', bucket: 'bucket'});
-    }).not.toThrow('GCSAdapter requires an bucket')
-  })
+      return new GCSAdapter({ projectId: 'projectId' , keyFilename: 'keyFilename', bucket: 'bucket'});
+    }).toNotThrow('GCSAdapter requires an bucket')
+  });
 
   if (process.env.GCP_PROJECT_ID && process.env.GCP_KEYFILE_PATH && process.env.GCS_BUCKET) {
     // Should be initialized from the env
     let gcsAdapter = new GCSAdapter();
     filesAdapterTests.testAdapter("GCSAdapter", gcs);
   }
-})
+
+});

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -1,6 +1,5 @@
 'use strict';
-let filesAdapterTests = require('parse-server-conformance-tests').files,
-  expect = require('expect');
+let filesAdapterTests = require('parse-server-conformance-tests').files;
 
 let GCSAdapter = require('../index.js');
 
@@ -31,11 +30,11 @@ describe('GCSAdapter tests', () => {
   it('should not throw when initialized properly', () => {
     expect(() => {
       return new GCSAdapter('projectId', 'keyFilename', 'bucket');
-    }).toNotThrow();
+    }).not.toThrow();
 
     expect(() => {
       return new GCSAdapter({ projectId: 'projectId' , keyFilename: 'keyFilename', bucket: 'bucket'});
-    }).toNotThrow('GCSAdapter requires an bucket')
+    }).not.toThrow();
   });
 
   if (process.env.GCP_PROJECT_ID && process.env.GCP_KEYFILE_PATH && process.env.GCS_BUCKET) {


### PR DESCRIPTION
Remove requirement for projectId & keyFilename, which when executed in Google managed environment can be inherited.

Also, a small but important change is to copy construct options before altering its values.
