### PR TITLE
Adds description to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@parse/gcs-files-adapter",
   "version": "1.1.2",
-  "description": "",
+  "description": "Google Cloud Storage adapter for parse-server",
   "main": "index.js",
   "dependencies": {
     "@google-cloud/storage": "^1.0.0"


### PR DESCRIPTION
Adds a description that isn't blank so we can control what shows up in search on npm [here](https://www.npmjs.com/search?q=%40parse%2Fgcs-files-adapter). Currently it just shows the build status code, which isn't really a great description :/.

This is for the issue noted in #21 .